### PR TITLE
Add compatibility with TerminalFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## ScanPlus [1.0.3] - 2024-03-22
+
+### Added
+
+- Added compatibility with `TerminalFormatter`. ([#1](https://github.com/AidanTweedy/scanplus/issues/1))
+
+### Changed
+
+- Updated README
+
+### Removed
+
+- None
+
 ## ScanPlus [1.0.2] - 2024-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alternatively, you can use Thunderstore Mod Manager.
 
 ## Usage
 
-To use the upgraded scanner the player must purchase the `Infrared Scanner` ship upgrade. Doing so will add information about which creatures are spawned on the current moon.
+To use the upgraded scanner, the player must purchase the `Infrared Scanner` ship upgrade. Doing so will add information to the scan results about which creatures are spawned on the current moon.
 
 The need for the `Infrared Scanner` upgrade can be disabled in the config file (see below), allowing for the enhanced scan without having to purchase the upgrade.
 

--- a/ScanPlus/Patches/TerminalFormatter.cs
+++ b/ScanPlus/Patches/TerminalFormatter.cs
@@ -5,9 +5,8 @@ namespace ScanPlus
     [HarmonyPatch(typeof(Terminal))]
     public class TFCompatibility
     {
-        [HarmonyPostfix, HarmonyPriority(Priority.Last)]
         [HarmonyPatch("TextPostProcess")]
-        private static void TextPostProcessPrefixPostFix(string modifiedDisplayText, TerminalNode node, Terminal __instance)
+        public static void TextPostProcessPrefixPostFix(string modifiedDisplayText, TerminalNode node, Terminal __instance)
         {
             if (node.name == "ScanInfo")
             {

--- a/ScanPlus/Patches/TerminalFormatter.cs
+++ b/ScanPlus/Patches/TerminalFormatter.cs
@@ -1,0 +1,18 @@
+using HarmonyLib;
+
+namespace ScanPlus
+{
+    [HarmonyPatch(typeof(Terminal))]
+    public class TFCompatibility
+    {
+        [HarmonyPostfix, HarmonyPriority(Priority.Last)]
+        [HarmonyPatch("TextPostProcess")]
+        private static void TextPostProcessPrefixPostFix(string modifiedDisplayText, TerminalNode node, Terminal __instance)
+        {
+            if (node.name == "ScanInfo")
+            {
+                __instance.currentText += ScanPlus.BuildEnemyCountString();
+            }
+        }
+    }
+}

--- a/ScanPlus/Patches/TerminalFormatter.cs
+++ b/ScanPlus/Patches/TerminalFormatter.cs
@@ -8,7 +8,7 @@ namespace ScanPlus
         [HarmonyPatch("TextPostProcess")]
         public static void TextPostProcessPrefixPostFix(string modifiedDisplayText, TerminalNode node, Terminal __instance)
         {
-            if (node.name == "ScanInfo")
+            if (node.name == "ScanInfo" && (ScanPlus.scanner.unlockable.hasBeenUnlockedByPlayer || !ScanPlus.m_shipUpgrade))
             {
                 __instance.currentText += ScanPlus.BuildEnemyCountString();
             }

--- a/ScanPlus/Patches/TerminalFormatter.cs
+++ b/ScanPlus/Patches/TerminalFormatter.cs
@@ -8,7 +8,7 @@ namespace ScanPlus
         [HarmonyPatch("TextPostProcess")]
         public static void TextPostProcessPrefixPostFix(string modifiedDisplayText, TerminalNode node, Terminal __instance)
         {
-            if (node.name == "ScanInfo" && (ScanPlus.scanner.unlockable.hasBeenUnlockedByPlayer || !ScanPlus.m_shipUpgrade))
+            if (node.name == "ScanInfo" && ScanPlus.UseUpgradedScan())
             {
                 __instance.currentText += ScanPlus.BuildEnemyCountString();
             }

--- a/ScanPlus/ScanPlus.cs
+++ b/ScanPlus/ScanPlus.cs
@@ -97,15 +97,11 @@ namespace ScanPlus
 
         private static void OnTerminalParsedSentence(object sender, Events.TerminalParseSentenceEventArgs e)
         {
-            if (e.ReturnedNode.name != "ScanInfo")
-                return;
-
-            if (m_shipUpgrade && !scanner.unlockable.hasBeenUnlockedByPlayer)
-                return;
-
-            var delimiter = "\n";
-
-            e.ReturnedNode.displayText = e.ReturnedNode.displayText.Split(delimiter)[0] + delimiter + BuildEnemyCountString();
+            if (e.ReturnedNode.name == "ScanInfo" && UseUpgradedScan())
+            {
+                var delimiter = "\n";
+                e.ReturnedNode.displayText = e.ReturnedNode.displayText.Split(delimiter)[0] + delimiter + BuildEnemyCountString();
+            }
         }
 
         internal static string BuildEnemyCountString()
@@ -153,6 +149,17 @@ namespace ScanPlus
 
             sb.AppendLine();
             return sb.ToString();
+        }
+        
+        internal static bool UseUpgradedScan()
+        {
+            if (!m_shipUpgrade)
+                return true;
+            
+            if (scanner.unlockable.hasBeenUnlockedByPlayer)
+                return true;
+            
+            return false;
         }
     }
 }

--- a/ScanPlus/ScanPlus.cs
+++ b/ScanPlus/ScanPlus.cs
@@ -28,11 +28,11 @@ namespace ScanPlus
             config_DetailLevel,
             config_ShipUpgrade,
             config_UpgradePrice;
-        private static int m_detailLevel;
-        private static bool m_shipUpgrade;
-        private static int m_upgradePrice;
+        internal static int m_detailLevel;
+        internal static bool m_shipUpgrade;
+        internal static int m_upgradePrice;
 
-        private static Unlockables.RegisteredUnlockable scanner;
+        internal static Unlockables.RegisteredUnlockable scanner;
         private const string UpgradeName = "Infrared Scanner";
         private const string UpgradeInfo = "\nUpgrades the ship's scanner with an infrared sensor, allowing for the detection of lifeforms present on the current moon.\n";
         private const string DefaultString = "\nNo life detected.\n\n";

--- a/ScanPlus/ScanPlus.cs
+++ b/ScanPlus/ScanPlus.cs
@@ -23,6 +23,7 @@ namespace ScanPlus
     {
         private static ManualLogSource _log = null!;
         internal static Harmony harmony = new(PluginInfo.PLUGIN_GUID);
+        
         private static ConfigEntry<int>
             config_DetailLevel,
             config_ShipUpgrade,
@@ -32,7 +33,6 @@ namespace ScanPlus
         private static int m_upgradePrice;
 
         private static Unlockables.RegisteredUnlockable scanner;
-
         private const string UpgradeName = "Infrared Scanner";
         private const string UpgradeInfo = "\nUpgrades the ship's scanner with an infrared sensor, allowing for the detection of lifeforms present on the current moon.\n";
         private const string DefaultString = "\nNo life detected.\n\n";

--- a/ScanPlus/ScanPlus.cs
+++ b/ScanPlus/ScanPlus.cs
@@ -18,6 +18,7 @@ namespace ScanPlus
 {
     [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
     [BepInDependency("atomic.terminalapi")]
+    [BepInDependency("TerminalFormatter", BepInDependency.DependencyFlags.SoftDependency)]
     public class ScanPlus : BaseUnityPlugin
     {
         private static ManualLogSource _log = null!;
@@ -46,12 +47,12 @@ namespace ScanPlus
 
             if (Chainloader.PluginInfos.ContainsKey("TerminalFormatter"))
             {
+                Logger.LogInfo($"{PluginInfo.PLUGIN_GUID}: applying compatibility patch for TerminalFormatter");
+                
                 var original = AccessTools.Method(typeof(Terminal), "TextPostProcess");
                 var postfix = new HarmonyMethod(typeof(TFCompatibility).GetMethod("TextPostProcessPrefixPostFix"));
             
                 harmony.Patch(original, null, postfix);
-
-                Logger.LogInfo($"{PluginInfo.PLUGIN_GUID}: applying compatibility patch for TerminalFormatter");
             }
 
             Events.TerminalParsedSentence += OnTerminalParsedSentence;

--- a/ScanPlus/ScanPlus.csproj
+++ b/ScanPlus/ScanPlus.csproj
@@ -50,10 +50,6 @@
     <Reference Include="LethalLib">
       <HintPath>../lib/LethalLib/LethalLib.dll</HintPath>
     </Reference>
-
-    <Reference Include="TerminalFormatter" PrivateAssets="All">
-      <HintPath>../lib/TerminalFormatter.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
   <Target Name="SetPluginVersion" BeforeTargets="AddGeneratedFile" DependsOnTargets="MinVer">

--- a/ScanPlus/ScanPlus.csproj
+++ b/ScanPlus/ScanPlus.csproj
@@ -50,6 +50,10 @@
     <Reference Include="LethalLib">
       <HintPath>../lib/LethalLib/LethalLib.dll</HintPath>
     </Reference>
+
+    <Reference Include="TerminalFormatter" PrivateAssets="All">
+      <HintPath>../lib/TerminalFormatter.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <Target Name="SetPluginVersion" BeforeTargets="AddGeneratedFile" DependsOnTargets="MinVer">

--- a/ScanPlus/ScanPlus.csproj
+++ b/ScanPlus/ScanPlus.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ScanPlus</AssemblyName>
     <Description>Ship scanner mod for Lethal Company</Description>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <PackageId>AidanTweedy.ScanPlus</PackageId>


### PR DESCRIPTION
TerminalFormatter currently prevents the upgraded scan text from displaying.